### PR TITLE
add Validate and Setup tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry', "~> 0.9.0"
+
+gem 'dk', :github => "redding/dk", :branch => "master"

--- a/dk-abdeploy.gemspec
+++ b/dk-abdeploy.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.1"])
+  gem.add_development_dependency("assert",      ["~> 2.16.1"])
+  gem.add_development_dependency("much-plugin", ["~> 0.2.0"])
+
+  gem.add_dependency("dk", ["~> 0.0.1"])
 
 end

--- a/lib/dk-abdeploy.rb
+++ b/lib/dk-abdeploy.rb
@@ -2,4 +2,20 @@ require "dk-abdeploy/version"
 
 module Dk; end
 module Dk::ABDeploy
+
+  SHARED_DIR_NAME    = 'shared'.freeze
+  RELEASES_DIR_NAME  = 'releases'.freeze
+  RELEASE_A_DIR_NAME = 'A'.freeze
+  RELEASE_B_DIR_NAME = 'B'.freeze
+  CURRENT_LINK_NAME  = 'current'.freeze
+
+  ROOT_PARAM_NAME          = 'dk_abdeploy_root'.freeze
+  SHARED_DIR_PARAM_NAME    = 'dk_abdeploy_shared_dir'.freeze
+  RELEASES_DIR_PARAM_NAME  = 'dk_abdeploy_releases_dir'.freeze
+  RELEASE_A_DIR_PARAM_NAME = 'dk_abdeploy_release_a_dir'.freeze
+  RELEASE_B_DIR_PARAM_NAME = 'dk_abdeploy_release_b_dir'.freeze
+  REPO_PARAM_NAME          = 'dk_abdeploy_repo'.freeze
+
+  SSH_HOSTS_GROUP_NAME = 'dk_abdeploy_servers'.freeze
+
 end

--- a/lib/dk-abdeploy/setup.rb
+++ b/lib/dk-abdeploy/setup.rb
@@ -1,0 +1,43 @@
+require 'pathname'
+require 'dk/task'
+require 'dk-abdeploy/validate'
+
+module Dk::ABDeploy
+
+  class Setup
+    include Dk::Task
+
+    desc "(dk-abdeploy) create the dirs and clone the repos for the A/B deploy scheme"
+
+    before Validate
+
+    ssh_hosts SSH_HOSTS_GROUP_NAME
+
+    def run!
+      # make the expected dirs if not already made
+      mkdirs = [
+        params[ROOT_PARAM_NAME].to_s,
+        params[SHARED_DIR_PARAM_NAME],
+        params[RELEASES_DIR_PARAM_NAME],
+        params[RELEASE_A_DIR_PARAM_NAME],
+        params[RELEASE_B_DIR_PARAM_NAME]
+      ]
+      ssh "mkdir -p #{mkdirs.join(' ')}"
+
+      # clone the A/B release repos if not already cloned
+      ssh clone_cmd(params[REPO_PARAM_NAME], params[RELEASE_A_DIR_PARAM_NAME])
+      ssh clone_cmd(params[REPO_PARAM_NAME], params[RELEASE_B_DIR_PARAM_NAME])
+    end
+
+    private
+
+    def clone_cmd(repo, release_dir)
+      "if [ -d #{release_dir}/.git ]; " \
+      "then echo 'git repo already cloned to #{release_dir}'; " \
+      "else git clone -q  #{repo} #{release_dir}; " \
+      "fi"
+    end
+
+  end
+
+end

--- a/lib/dk-abdeploy/validate.rb
+++ b/lib/dk-abdeploy/validate.rb
@@ -1,0 +1,33 @@
+require 'pathname'
+require 'dk/task'
+require 'dk-abdeploy'
+
+module Dk::ABDeploy
+
+  class Validate
+    include Dk::Task
+
+    desc "(dk-abdeploy) validate the required dk-abdeploy params"
+
+    def run!
+      # validate required params are set
+      if params[ROOT_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{ROOT_PARAM_NAME.inspect} param set"
+      end
+      if params[REPO_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{REPO_PARAM_NAME.inspect} param set"
+      end
+
+      # set common required params for downstream tasks
+      deploy_root = Pathname.new(params[ROOT_PARAM_NAME])
+      set_param(SHARED_DIR_PARAM_NAME, deploy_root.join(SHARED_DIR_NAME).to_s)
+
+      releases_dir = deploy_root.join(RELEASES_DIR_NAME)
+      set_param(RELEASES_DIR_PARAM_NAME,  releases_dir.to_s)
+      set_param(RELEASE_A_DIR_PARAM_NAME, releases_dir.join(RELEASE_A_DIR_NAME).to_s)
+      set_param(RELEASE_B_DIR_PARAM_NAME, releases_dir.join(RELEASE_B_DIR_NAME).to_s)
+    end
+
+  end
+
+end

--- a/test/support/validate.rb
+++ b/test/support/validate.rb
@@ -1,0 +1,35 @@
+require 'much-plugin'
+require 'dk/task'
+require 'dk-abdeploy/validate'
+
+class Dk::ABDeploy::Validate
+
+  module TestHelpers
+    include MuchPlugin
+
+    plugin_included do
+      include Dk::Task::TestHelpers
+
+      setup do
+        @root      = Factory.path
+        @repo      = Factory.string
+        @shared    = File.join(@root,     Dk::ABDeploy::SHARED_DIR_NAME)
+        @releases  = File.join(@root,     Dk::ABDeploy::RELEASES_DIR_NAME)
+        @release_a = File.join(@releases, Dk::ABDeploy::RELEASE_A_DIR_NAME)
+        @release_b = File.join(@releases, Dk::ABDeploy::RELEASE_B_DIR_NAME)
+
+        @params = {
+          Dk::ABDeploy::ROOT_PARAM_NAME          => @root,
+          Dk::ABDeploy::REPO_PARAM_NAME          => @repo,
+          Dk::ABDeploy::SHARED_DIR_PARAM_NAME    => @shared,
+          Dk::ABDeploy::RELEASES_DIR_PARAM_NAME  => @releases,
+          Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME => @release_a,
+          Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME => @release_b
+        }
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/dk-abdeploy_tests.rb
+++ b/test/unit/dk-abdeploy_tests.rb
@@ -1,0 +1,36 @@
+require 'assert'
+require 'dk-abdeploy'
+
+module Dk::ABDeploy
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy"
+    setup do
+      @deploy_module = Dk::ABDeploy
+    end
+    subject{ @deploy_module }
+
+    should "know its dir/link names" do
+      assert_equal 'shared',   subject::SHARED_DIR_NAME
+      assert_equal 'releases', subject::RELEASES_DIR_NAME
+      assert_equal 'A',        subject::RELEASE_A_DIR_NAME
+      assert_equal 'B',        subject::RELEASE_B_DIR_NAME
+      assert_equal 'current',  subject::CURRENT_LINK_NAME
+    end
+
+    should "know its param names" do
+      assert_equal 'dk_abdeploy_root',          subject::ROOT_PARAM_NAME
+      assert_equal 'dk_abdeploy_shared_dir',    subject::SHARED_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_releases_dir',  subject::RELEASES_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_release_a_dir', subject::RELEASE_A_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_release_b_dir', subject::RELEASE_B_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_repo',          subject::REPO_PARAM_NAME
+    end
+
+    should "know its ssh hosts group name" do
+      assert_equal 'dk_abdeploy_servers', subject::SSH_HOSTS_GROUP_NAME
+    end
+
+  end
+
+end

--- a/test/unit/setup_tests.rb
+++ b/test/unit/setup_tests.rb
@@ -1,0 +1,84 @@
+require 'assert'
+require 'dk-abdeploy/setup'
+
+require 'dk/task'
+require 'dk/task_run'
+require 'dk-abdeploy'
+require 'test/support/validate'
+
+class Dk::ABDeploy::Setup
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::Setup"
+    setup do
+      @task_class = Dk::ABDeploy::Setup
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-abdeploy) create the dirs and clone the repos for the A/B deploy scheme"
+      assert_equal exp, subject.description
+    end
+
+    should "run the Validate task as a before callback" do
+      assert_equal [Dk::ABDeploy::Validate], subject.before_callback_task_classes
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::ABDeploy::Validate::TestHelpers
+
+    desc "when init"
+    setup do
+      @runner = test_runner(@task_class, :params => @params)
+      @task = @runner.task
+    end
+    subject{ @task }
+
+    should "know its ssh hosts" do
+      assert_equal Dk::ABDeploy::SSH_HOSTS_GROUP_NAME, subject.dk_dsl_ssh_hosts
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+    subject{ @runner }
+
+    should "run the Validate task callback and 3 ssh cmds" do
+      assert_equal 4, subject.runs.size
+    end
+
+    should "run ssh cmds to make the dirs and clone the A/B repos" do
+      _, mkdir_ssh, clone_a_ssh, clone_b_ssh = subject.runs
+
+      exp = "mkdir -p #{@root} #{@shared} #{@releases} #{@release_a} #{@release_b}"
+      assert_equal exp, mkdir_ssh.cmd_str
+
+      exp = clone_cmd(@repo, @release_a)
+      assert_equal exp, clone_a_ssh.cmd_str
+
+      exp = clone_cmd(@repo, @release_b)
+      assert_equal exp, clone_b_ssh.cmd_str
+    end
+
+    private
+
+    def clone_cmd(repo, release_dir)
+      "if [ -d #{release_dir}/.git ]; " \
+      "then echo 'git repo already cloned to #{release_dir}'; " \
+      "else git clone -q  #{repo} #{release_dir}; " \
+      "fi"
+    end
+
+  end
+
+end

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -1,0 +1,83 @@
+require 'assert'
+require 'dk-abdeploy/validate'
+
+require 'dk/task'
+require 'dk-abdeploy'
+
+class Dk::ABDeploy::Validate
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::Validate"
+    setup do
+      @task_class = Dk::ABDeploy::Validate
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-abdeploy) validate the required dk-abdeploy params"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class RunTests < UnitTests
+    include Dk::Task::TestHelpers
+
+    desc "when run"
+    setup do
+      @root = Factory.path
+      @repo = Factory.string
+      @params = {
+        Dk::ABDeploy::ROOT_PARAM_NAME => @root,
+        Dk::ABDeploy::REPO_PARAM_NAME => @repo
+      }
+      @runner = test_runner(@task_class, :params => @params)
+      @runner.run
+    end
+    subject{ @runner }
+
+    should "set some params based on the root param" do
+      exp = File.join(@root, Dk::ABDeploy::SHARED_DIR_NAME)
+      assert_equal exp, subject.params[Dk::ABDeploy::SHARED_DIR_PARAM_NAME]
+
+      exp = File.join(@root, Dk::ABDeploy::RELEASES_DIR_NAME)
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASES_DIR_PARAM_NAME]
+
+      exp_releases_dir = exp
+
+      exp = File.join(exp_releases_dir, Dk::ABDeploy::RELEASE_A_DIR_NAME)
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+
+      exp = File.join(exp_releases_dir, Dk::ABDeploy::RELEASE_B_DIR_NAME)
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+    end
+
+    should "complain if the root/repo params aren't set" do
+      value = [nil, ''].sample
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::ROOT_PARAM_NAME => value,
+        Dk::ABDeploy::REPO_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::ROOT_PARAM_NAME => Factory.path,
+        Dk::ABDeploy::REPO_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::ROOT_PARAM_NAME => value,
+        Dk::ABDeploy::REPO_PARAM_NAME => Factory.string
+      })
+      assert_raises(ArgumentError){ runner.run }
+    end
+
+  end
+
+end


### PR DESCRIPTION
These tasks are used to setup a deploy.  They validate the
params and create the deploy dirs and clone the A/B repos.

I chose to do the validation logic as a callback task as I need
to also use it as a callback for the coming Update and Link tasks.

@jcredding ready for review.
