### PR TITLE
add Update and Link tasks

### DIFF
--- a/lib/dk-abdeploy.rb
+++ b/lib/dk-abdeploy.rb
@@ -9,12 +9,17 @@ module Dk::ABDeploy
   RELEASE_B_DIR_NAME = 'B'.freeze
   CURRENT_LINK_NAME  = 'current'.freeze
 
-  ROOT_PARAM_NAME          = 'dk_abdeploy_root'.freeze
-  SHARED_DIR_PARAM_NAME    = 'dk_abdeploy_shared_dir'.freeze
-  RELEASES_DIR_PARAM_NAME  = 'dk_abdeploy_releases_dir'.freeze
-  RELEASE_A_DIR_PARAM_NAME = 'dk_abdeploy_release_a_dir'.freeze
-  RELEASE_B_DIR_PARAM_NAME = 'dk_abdeploy_release_b_dir'.freeze
-  REPO_PARAM_NAME          = 'dk_abdeploy_repo'.freeze
+  ROOT_PARAM_NAME                = 'dk_abdeploy_root'.freeze
+  SHARED_DIR_PARAM_NAME          = 'dk_abdeploy_shared_dir'.freeze
+  CURRENT_DIR_PARAM_NAME         = 'dk_abdeploy_current_dir'.freeze
+  RELEASES_DIR_PARAM_NAME        = 'dk_abdeploy_releases_dir'.freeze
+  RELEASE_A_DIR_PARAM_NAME       = 'dk_abdeploy_release_a_dir'.freeze
+  RELEASE_B_DIR_PARAM_NAME       = 'dk_abdeploy_release_b_dir'.freeze
+  CURRENT_RELEASE_DIR_PARAM_NAME = 'dk_abdeploy_current_release_dir'.freeze
+  DEPLOY_RELEASE_DIR_PARAM_NAME  = 'dk_abdeploy_deploy_release_dir'.freeze
+  REPO_PARAM_NAME                = 'dk_abdeploy_repo'.freeze
+  REF_PARAM_NAME                 = 'dk_abdeploy_ref'.freeze
+  PRIMARY_SSH_HOST_PARAM_NAME    = 'dk_abdeploy_primary_ssh_host'.freeze
 
   SSH_HOSTS_GROUP_NAME = 'dk_abdeploy_servers'.freeze
 

--- a/lib/dk-abdeploy/link.rb
+++ b/lib/dk-abdeploy/link.rb
@@ -1,0 +1,30 @@
+require 'dk/task'
+require 'dk-abdeploy/validate'
+require 'dk-abdeploy'
+
+module Dk::ABDeploy
+
+  class Link
+    include Dk::Task
+
+    desc "(dk-abdeploy) link the deploy release dir as the current dir"
+
+    before Validate
+
+    ssh_hosts SSH_HOSTS_GROUP_NAME
+
+    def run!
+      # validate required params are set
+      if params[DEPLOY_RELEASE_DIR_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{DEPLOY_RELEASE_DIR_PARAM_NAME.inspect} param set"
+      end
+
+      # link the deploy release dir as the current dir
+      curr_dir    = params[CURRENT_DIR_PARAM_NAME]
+      release_dir = params[DEPLOY_RELEASE_DIR_PARAM_NAME]
+      ssh! "rm -f #{curr_dir} && ln -s #{release_dir} #{curr_dir}"
+    end
+
+  end
+
+end

--- a/lib/dk-abdeploy/setup.rb
+++ b/lib/dk-abdeploy/setup.rb
@@ -1,6 +1,6 @@
-require 'pathname'
 require 'dk/task'
 require 'dk-abdeploy/validate'
+require 'dk-abdeploy'
 
 module Dk::ABDeploy
 
@@ -22,16 +22,16 @@ module Dk::ABDeploy
         params[RELEASE_A_DIR_PARAM_NAME],
         params[RELEASE_B_DIR_PARAM_NAME]
       ]
-      ssh "mkdir -p #{mkdirs.join(' ')}"
+      ssh! "mkdir -p #{mkdirs.join(' ')}"
 
       # clone the A/B release repos if not already cloned
-      ssh clone_cmd(params[REPO_PARAM_NAME], params[RELEASE_A_DIR_PARAM_NAME])
-      ssh clone_cmd(params[REPO_PARAM_NAME], params[RELEASE_B_DIR_PARAM_NAME])
+      ssh! clone_cmd_str(params[REPO_PARAM_NAME], params[RELEASE_A_DIR_PARAM_NAME])
+      ssh! clone_cmd_str(params[REPO_PARAM_NAME], params[RELEASE_B_DIR_PARAM_NAME])
     end
 
     private
 
-    def clone_cmd(repo, release_dir)
+    def clone_cmd_str(repo, release_dir)
       "if [ -d #{release_dir}/.git ]; " \
       "then echo 'git repo already cloned to #{release_dir}'; " \
       "else git clone -q  #{repo} #{release_dir}; " \

--- a/lib/dk-abdeploy/update.rb
+++ b/lib/dk-abdeploy/update.rb
@@ -1,0 +1,57 @@
+require 'dk/task'
+require 'dk-abdeploy/validate'
+require 'dk-abdeploy'
+
+module Dk::ABDeploy
+
+  class Update
+    include Dk::Task
+
+    desc "(dk-abdeploy) updated the non-current release's source"
+
+    before Validate
+
+    ssh_hosts SSH_HOSTS_GROUP_NAME
+
+    def run!
+      # validate required params are set
+      if params[REF_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{REF_PARAM_NAME.inspect} param set"
+      end
+      if params[PRIMARY_SSH_HOST_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{PRIMARY_SSH_HOST_PARAM_NAME.inspect} param set"
+      end
+
+      # lookup the current release dir; set current/deploy release dir params
+      rl_cmd = cmd readlink_cmd_str(params[CURRENT_DIR_PARAM_NAME], {
+        :host => params[PRIMARY_SSH_HOST_PARAM_NAME]
+      })
+      set_param(CURRENT_RELEASE_DIR_PARAM_NAME, rl_cmd.stdout.strip)
+
+      release_dirs = [
+        params[RELEASE_A_DIR_PARAM_NAME],
+        params[RELEASE_B_DIR_PARAM_NAME]
+      ]
+      release_dirs.delete(params[CURRENT_RELEASE_DIR_PARAM_NAME])
+      set_param(DEPLOY_RELEASE_DIR_PARAM_NAME, release_dirs.first)
+
+      # reset the deploy release git repo
+      ssh! git_reset_cmd_str(params[DEPLOY_RELEASE_DIR_PARAM_NAME], params[REF_PARAM_NAME])
+    end
+
+    private
+
+    def readlink_cmd_str(link, ssh_opts)
+      ssh_cmd_str("readlink #{link}", ssh_opts)
+    end
+
+    def git_reset_cmd_str(repo_dir, ref)
+      "cd #{repo_dir} && " \
+      "git fetch -q origin && " \
+      "git reset -q --hard #{ref} && " \
+      "git clean -q -d -x -f"
+    end
+
+  end
+
+end

--- a/lib/dk-abdeploy/validate.rb
+++ b/lib/dk-abdeploy/validate.rb
@@ -20,7 +20,8 @@ module Dk::ABDeploy
 
       # set common required params for downstream tasks
       deploy_root = Pathname.new(params[ROOT_PARAM_NAME])
-      set_param(SHARED_DIR_PARAM_NAME, deploy_root.join(SHARED_DIR_NAME).to_s)
+      set_param(SHARED_DIR_PARAM_NAME,  deploy_root.join(SHARED_DIR_NAME).to_s)
+      set_param(CURRENT_DIR_PARAM_NAME, deploy_root.join(CURRENT_LINK_NAME).to_s)
 
       releases_dir = deploy_root.join(RELEASES_DIR_NAME)
       set_param(RELEASES_DIR_PARAM_NAME,  releases_dir.to_s)

--- a/test/support/validate.rb
+++ b/test/support/validate.rb
@@ -14,6 +14,7 @@ class Dk::ABDeploy::Validate
         @root      = Factory.path
         @repo      = Factory.string
         @shared    = File.join(@root,     Dk::ABDeploy::SHARED_DIR_NAME)
+        @current   = File.join(@root,     Dk::ABDeploy::CURRENT_LINK_NAME)
         @releases  = File.join(@root,     Dk::ABDeploy::RELEASES_DIR_NAME)
         @release_a = File.join(@releases, Dk::ABDeploy::RELEASE_A_DIR_NAME)
         @release_b = File.join(@releases, Dk::ABDeploy::RELEASE_B_DIR_NAME)
@@ -22,6 +23,7 @@ class Dk::ABDeploy::Validate
           Dk::ABDeploy::ROOT_PARAM_NAME          => @root,
           Dk::ABDeploy::REPO_PARAM_NAME          => @repo,
           Dk::ABDeploy::SHARED_DIR_PARAM_NAME    => @shared,
+          Dk::ABDeploy::CURRENT_DIR_PARAM_NAME   => @current,
           Dk::ABDeploy::RELEASES_DIR_PARAM_NAME  => @releases,
           Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME => @release_a,
           Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME => @release_b

--- a/test/unit/dk-abdeploy_tests.rb
+++ b/test/unit/dk-abdeploy_tests.rb
@@ -19,12 +19,18 @@ module Dk::ABDeploy
     end
 
     should "know its param names" do
-      assert_equal 'dk_abdeploy_root',          subject::ROOT_PARAM_NAME
-      assert_equal 'dk_abdeploy_shared_dir',    subject::SHARED_DIR_PARAM_NAME
-      assert_equal 'dk_abdeploy_releases_dir',  subject::RELEASES_DIR_PARAM_NAME
-      assert_equal 'dk_abdeploy_release_a_dir', subject::RELEASE_A_DIR_PARAM_NAME
-      assert_equal 'dk_abdeploy_release_b_dir', subject::RELEASE_B_DIR_PARAM_NAME
-      assert_equal 'dk_abdeploy_repo',          subject::REPO_PARAM_NAME
+      s = subject
+      assert_equal 'dk_abdeploy_root',                s::ROOT_PARAM_NAME
+      assert_equal 'dk_abdeploy_shared_dir',          s::SHARED_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_current_dir',         s::CURRENT_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_releases_dir',        s::RELEASES_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_release_a_dir',       s::RELEASE_A_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_release_b_dir',       s::RELEASE_B_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_current_release_dir', s::CURRENT_RELEASE_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_deploy_release_dir',  s::DEPLOY_RELEASE_DIR_PARAM_NAME
+      assert_equal 'dk_abdeploy_repo',                s::REPO_PARAM_NAME
+      assert_equal 'dk_abdeploy_ref',                 s::REF_PARAM_NAME
+      assert_equal 'dk_abdeploy_primary_ssh_host',    s::PRIMARY_SSH_HOST_PARAM_NAME
     end
 
     should "know its ssh hosts group name" do

--- a/test/unit/link_tests.rb
+++ b/test/unit/link_tests.rb
@@ -1,0 +1,84 @@
+require 'assert'
+require 'dk-abdeploy/link'
+
+require 'dk/task'
+require 'dk/task_run'
+require 'dk-abdeploy'
+require 'test/support/validate'
+
+class Dk::ABDeploy::Link
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::Link"
+    setup do
+      @task_class = Dk::ABDeploy::Link
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-abdeploy) link the deploy release dir as the current dir"
+      assert_equal exp, subject.description
+    end
+
+    should "run the Validate task as a before callback" do
+      assert_equal [Dk::ABDeploy::Validate], subject.before_callback_task_classes
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::ABDeploy::Validate::TestHelpers
+
+    desc "when init"
+    setup do
+      release_dirs = [
+        @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME],
+        @params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+      ]
+      @params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME] = release_dirs.sample
+
+      @runner = test_runner(@task_class, :params => @params)
+      @task = @runner.task
+    end
+    subject{ @task }
+
+    should "know its ssh hosts" do
+      assert_equal Dk::ABDeploy::SSH_HOSTS_GROUP_NAME, subject.dk_dsl_ssh_hosts
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+    subject{ @runner }
+
+    should "run the Validate task callback and 1 ssh cmd" do
+      assert_equal 2, subject.runs.size
+    end
+
+    should "run an ssh cmds to link the deploy release dir as the current dir" do
+      _, link_ssh = subject.runs
+      curr_dir    = @params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]
+      release_dir = @params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME]
+
+      exp = "rm -f #{curr_dir} && ln -s #{release_dir} #{curr_dir}"
+      assert_equal exp, link_ssh.cmd_str
+    end
+
+    should "complain if the deploy release dir param isn't set" do
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME => [nil, ''].sample
+      })
+      assert_raises(ArgumentError){ runner.run }
+    end
+
+  end
+
+end

--- a/test/unit/setup_tests.rb
+++ b/test/unit/setup_tests.rb
@@ -63,16 +63,16 @@ class Dk::ABDeploy::Setup
       exp = "mkdir -p #{@root} #{@shared} #{@releases} #{@release_a} #{@release_b}"
       assert_equal exp, mkdir_ssh.cmd_str
 
-      exp = clone_cmd(@repo, @release_a)
+      exp = clone_cmd_str(@repo, @release_a)
       assert_equal exp, clone_a_ssh.cmd_str
 
-      exp = clone_cmd(@repo, @release_b)
+      exp = clone_cmd_str(@repo, @release_b)
       assert_equal exp, clone_b_ssh.cmd_str
     end
 
     private
 
-    def clone_cmd(repo, release_dir)
+    def clone_cmd_str(repo, release_dir)
       "if [ -d #{release_dir}/.git ]; " \
       "then echo 'git repo already cloned to #{release_dir}'; " \
       "else git clone -q  #{repo} #{release_dir}; " \

--- a/test/unit/update_tests.rb
+++ b/test/unit/update_tests.rb
@@ -1,0 +1,153 @@
+require 'assert'
+require 'dk-abdeploy/update'
+
+require 'dk/task'
+require 'dk/task_run'
+require 'dk-abdeploy'
+require 'test/support/validate'
+
+class Dk::ABDeploy::Update
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::Update"
+    setup do
+      @task_class = Dk::ABDeploy::Update
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-abdeploy) updated the non-current release's source"
+      assert_equal exp, subject.description
+    end
+
+    should "run the Validate task as a before callback" do
+      assert_equal [Dk::ABDeploy::Validate], subject.before_callback_task_classes
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::ABDeploy::Validate::TestHelpers
+
+    desc "when init"
+    setup do
+      @params.merge!({
+        Dk::ABDeploy::REF_PARAM_NAME              => Factory.hex,
+        Dk::ABDeploy::PRIMARY_SSH_HOST_PARAM_NAME => "#{Factory.string}.example.com"
+      })
+      @runner = test_runner(@task_class, :params => @params)
+      @task = @runner.task
+    end
+    subject{ @task }
+
+    should "know its ssh hosts" do
+      assert_equal Dk::ABDeploy::SSH_HOSTS_GROUP_NAME, subject.dk_dsl_ssh_hosts
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @curr = @params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]
+      @host = @params[Dk::ABDeploy::PRIMARY_SSH_HOST_PARAM_NAME]
+
+      @rl_cmd_str = readlink_cmd_str(@task, @curr, :host => @host)
+
+      @curr_release_dir = Factory.path
+      @runner.stub_cmd(@rl_cmd_str){ |spy| spy.stdout = @curr_release_dir }
+
+      @runner.run
+    end
+    subject{ @runner }
+
+    should "run the Validate task callback, 1 cmd and 1 ssh cmd" do
+      assert_equal 3, subject.runs.size
+    end
+
+    should "run a readlink cmd over ssh to set the current release dir param" do
+      _, readlink_cmd, _ = subject.runs
+
+      assert_equal @rl_cmd_str, readlink_cmd.cmd_str
+
+      exp = @curr_release_dir
+      assert_equal exp, subject.params[Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME]
+    end
+
+    should "set the deploy release dir to the A dir by default" do
+      exp = @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+      assert_equal exp, subject.params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME]
+    end
+
+    should "set the deploy release dir to the non-current release dir" do
+      # if current is A, set deploy to B
+      curr_release_dir = @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+      runner = test_runner(@task_class, :params => @params)
+      runner.stub_cmd(@rl_cmd_str){ |spy| spy.stdout = curr_release_dir }
+      runner.run
+
+      exp = @params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+      assert_equal exp, runner.params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME]
+
+      # if current is B, set deploy to A
+      curr_release_dir = @params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+      runner = test_runner(@task_class, :params => @params)
+      runner.stub_cmd(@rl_cmd_str){ |spy| spy.stdout = curr_release_dir }
+      runner.run
+
+      exp = @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+      assert_equal exp, runner.params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME]
+    end
+
+    should "run an ssh cmd to reset the deploy release git repo" do
+      _, _, git_reset_ssh = subject.runs
+      repo_dir = @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+      ref      = @params[Dk::ABDeploy::REF_PARAM_NAME]
+
+      exp = git_reset_cmd_str(repo_dir, ref)
+      assert_equal exp, git_reset_ssh.cmd_str
+    end
+
+    should "complain if the ref/host params aren't set" do
+      value = [nil, ''].sample
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME              => value,
+        Dk::ABDeploy::PRIMARY_SSH_HOST_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME              => Factory.path,
+        Dk::ABDeploy::PRIMARY_SSH_HOST_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME              => value,
+        Dk::ABDeploy::PRIMARY_SSH_HOST_PARAM_NAME => Factory.string
+      })
+      assert_raises(ArgumentError){ runner.run }
+    end
+
+    private
+
+    def readlink_cmd_str(task, link, ssh_opts)
+      ssh_cmd_str(task, "readlink #{link}", ssh_opts)
+    end
+
+    def git_reset_cmd_str(repo_dir, ref)
+      "cd #{repo_dir} && " \
+      "git fetch -q origin && " \
+      "git reset -q --hard #{ref} && " \
+      "git clean -q -d -x -f"
+    end
+
+
+  end
+
+end

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -44,6 +44,9 @@ class Dk::ABDeploy::Validate
       exp = File.join(@root, Dk::ABDeploy::SHARED_DIR_NAME)
       assert_equal exp, subject.params[Dk::ABDeploy::SHARED_DIR_PARAM_NAME]
 
+      exp = File.join(@root, Dk::ABDeploy::CURRENT_LINK_NAME)
+      assert_equal exp, subject.params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]
+
       exp = File.join(@root, Dk::ABDeploy::RELEASES_DIR_NAME)
       assert_equal exp, subject.params[Dk::ABDeploy::RELEASES_DIR_PARAM_NAME]
 


### PR DESCRIPTION
These tasks update the deploy release repo's source and
links the deploy release dir and the current dir respectively.
These are more steps needed to rollout source in the A/B deploy
scheme.

The Update task first reads what the current link point to and
then sets the current release dir param to that value.  It then
sets the other release dir as the deploy release dir param. Once
the deploy release dir has been determined, the task then runs a
cmd to hard reset the git repo to the given ref param value.

The Link task is designed to be run at some point after the Update
task has run.  It takes deploy release dir param set by the Update
task and links it as the current dir.  This allows everything that
relies on the source to reference via this current link, which is
updated on deploy.

I also made of few changes to the setup and validate tasks:
- setup: switched to `ssh!` for making the ssh cmds so they'd
  raise an exception if they fail.
- setup: renamed the private cmd string method to be more
  specific as to what it returns.
- setup: removed the pathname require as it isn't needed.
- validate: added setting the current dir param (which is needed
  by the link task).

@jcredding ready for review.
