### PR TITLE
add CurrentGitBranch util module

### DIFF
--- a/lib/dk-abdeploy/utils/current_git_branch.rb
+++ b/lib/dk-abdeploy/utils/current_git_branch.rb
@@ -1,0 +1,24 @@
+module Dk; end
+module Dk::ABDeploy; end
+module Dk::ABDeploy::Utils
+
+  module CurrentGitBranch
+
+    def self.new(&block)
+      git_cmd_str = "git symbolic-ref HEAD"
+
+      # returns the cmd str if no block given
+      return git_cmd_str if block.nil?
+
+      # to get the value pass a block that runs the yielded cmd_str cmd, ex:
+      # current_branch_name = CurrentGitBranch.new do |cmd_str|
+      #   log_info "Fetching current git branch from HEAD"
+      #   cmd! cmd_str
+      # end
+      cmd = block.call(git_cmd_str)
+      cmd.stdout.split('/').last.strip
+    end
+
+  end
+
+end

--- a/test/unit/utils/current_git_branch_tests.rb
+++ b/test/unit/utils/current_git_branch_tests.rb
@@ -1,0 +1,41 @@
+require 'assert'
+require 'dk-abdeploy/utils/current_git_branch'
+
+require 'dk/task'
+
+module Dk::ABDeploy::Utils::CurrentGitBranch
+
+  class UnitTests < Assert::Context
+    include Dk::Task::TestHelpers
+
+    desc "Dk::ABDeploy::Utils::CurrentGitBranch"
+    setup do
+      @current_git_branch = Dk::ABDeploy::Utils::CurrentGitBranch
+    end
+    subject{ @current_git_branch }
+
+    should "return the cmd str to lookup the current git branch if no block given" do
+      assert_equal "git symbolic-ref HEAD", subject.new
+    end
+
+    should "yield the cmd str and expect a local cmd obj returned if a block given" do
+      task_class = Class.new do
+        include Dk::Task
+
+        def run!
+          ref = Dk::ABDeploy::Utils::CurrentGitBranch.new{ |cmd_str| cmd! cmd_str }
+          set_param 'git_ref', ref
+        end
+      end
+      runner = test_runner(task_class)
+
+      branch_name = Factory.string
+      runner.stub_cmd(subject.new){ |spy| spy.stdout = "refs/heads/#{branch_name}" }
+      runner.run
+
+      assert_equal branch_name, runner.params['git_ref']
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is a helper for looking up the current git branch in deploy
scripts.  If no block is given, this just returns a cmd str that
can be run that will return the raw info on stdout.  If a block
is given, it yields the cmd string and expects the block will
execute the cmd string and return the local cmd object.  It then
parses the stdout and returns the current branch name.

I chose to yield to a given block for running the cmd string.
This allows the user to control how the cmd is run (`cmd` vs
`cmd!`) and also allows the user to add any custom log message.
It also simplifies the API as I don't have to have some task
passed in and then instance eval on it.

Note: this is a rework of the cap-style version from the CapUtil
gem.

See https://github.com/redding/cap-util/blob/master/lib/cap-util/git_branch.rb for reference.

@jcredding ready for review.
