### PR TITLE
add a test helper for setting Validate task params/ivars

### DIFF
--- a/lib/dk-abdeploy/test_helpers.rb
+++ b/lib/dk-abdeploy/test_helpers.rb
@@ -1,0 +1,55 @@
+require 'much-plugin'
+
+module Dk::ABDeploy
+
+  module TestHelpers
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      def set_dk_abdeploy_validate_params
+        @dk_abdeploy_root = Factory.path
+        @dk_abdeploy_repo = Factory.string
+
+        @dk_abdeploy_shared = File.join(
+          @dk_abdeploy_root,
+          Dk::ABDeploy::SHARED_DIR_NAME
+        )
+        @dk_abdeploy_current = File.join(
+          @dk_abdeploy_root,
+          Dk::ABDeploy::CURRENT_LINK_NAME
+        )
+        @dk_abdeploy_releases = File.join(
+          @dk_abdeploy_root,
+          Dk::ABDeploy::RELEASES_DIR_NAME
+        )
+        @dk_abdeploy_release_a = File.join(
+          @dk_abdeploy_releases,
+          Dk::ABDeploy::RELEASE_A_DIR_NAME
+        )
+        @dk_abdeploy_release_b = File.join(
+          @dk_abdeploy_releases,
+          Dk::ABDeploy::RELEASE_B_DIR_NAME
+        )
+
+        @params = {
+          Dk::ABDeploy::ROOT_PARAM_NAME          => @dk_abdeploy_root,
+          Dk::ABDeploy::REPO_PARAM_NAME          => @dk_abdeploy_repo,
+          Dk::ABDeploy::SHARED_DIR_PARAM_NAME    => @dk_abdeploy_shared,
+          Dk::ABDeploy::CURRENT_DIR_PARAM_NAME   => @dk_abdeploy_current,
+          Dk::ABDeploy::RELEASES_DIR_PARAM_NAME  => @dk_abdeploy_releases,
+          Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME => @dk_abdeploy_release_a,
+          Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME => @dk_abdeploy_release_b
+        }
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/validate.rb
+++ b/test/support/validate.rb
@@ -1,5 +1,6 @@
 require 'much-plugin'
 require 'dk/task'
+require 'dk-abdeploy/test_helpers'
 require 'dk-abdeploy/validate'
 
 class Dk::ABDeploy::Validate
@@ -9,25 +10,18 @@ class Dk::ABDeploy::Validate
 
     plugin_included do
       include Dk::Task::TestHelpers
+      include Dk::ABDeploy::TestHelpers
 
       setup do
-        @root      = Factory.path
-        @repo      = Factory.string
-        @shared    = File.join(@root,     Dk::ABDeploy::SHARED_DIR_NAME)
-        @current   = File.join(@root,     Dk::ABDeploy::CURRENT_LINK_NAME)
-        @releases  = File.join(@root,     Dk::ABDeploy::RELEASES_DIR_NAME)
-        @release_a = File.join(@releases, Dk::ABDeploy::RELEASE_A_DIR_NAME)
-        @release_b = File.join(@releases, Dk::ABDeploy::RELEASE_B_DIR_NAME)
+        set_dk_abdeploy_validate_params
 
-        @params = {
-          Dk::ABDeploy::ROOT_PARAM_NAME          => @root,
-          Dk::ABDeploy::REPO_PARAM_NAME          => @repo,
-          Dk::ABDeploy::SHARED_DIR_PARAM_NAME    => @shared,
-          Dk::ABDeploy::CURRENT_DIR_PARAM_NAME   => @current,
-          Dk::ABDeploy::RELEASES_DIR_PARAM_NAME  => @releases,
-          Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME => @release_a,
-          Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME => @release_b
-        }
+        @root      = @dk_abdeploy_root
+        @repo      = @dk_abdeploy_repo
+        @shared    = @dk_abdeploy_shared
+        @current   = @dk_abdeploy_current
+        @releases  = @dk_abdeploy_releases
+        @release_a = @dk_abdeploy_release_a
+        @release_b = @dk_abdeploy_release_b
       end
 
     end

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -1,0 +1,55 @@
+require 'assert'
+require 'dk-abdeploy/test_helpers'
+
+require 'much-plugin'
+require 'dk-abdeploy'
+
+module Dk::ABDeploy::TestHelpers
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::TestHelpers"
+    setup do
+      @context_class = Class.new do
+        include Dk::ABDeploy::TestHelpers
+        attr_reader :dk_abdeploy_root, :dk_abdeploy_repo
+        attr_reader :dk_abdeploy_shared, :dk_abdeploy_current
+        attr_reader :dk_abdeploy_releases
+        attr_reader :dk_abdeploy_release_a, :dk_abdeploy_release_b
+        attr_reader :params
+      end
+      @context = @context_class.new
+    end
+    subject{ @context }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, @context_class
+    end
+
+    should "setup the ivars and params the validate task does" do
+      subject.set_dk_abdeploy_validate_params
+
+      exp = subject.dk_abdeploy_root
+      assert_equal exp, subject.params[Dk::ABDeploy::ROOT_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_repo
+      assert_equal exp, subject.params[Dk::ABDeploy::REPO_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_shared
+      assert_equal exp, subject.params[Dk::ABDeploy::SHARED_DIR_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_current
+      assert_equal exp, subject.params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_releases
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASES_DIR_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_release_a
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]
+
+      exp = subject.dk_abdeploy_release_b
+      assert_equal exp, subject.params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+    end
+
+  end
+
+end


### PR DESCRIPTION
I discovered, when testing a lib that used dk-abdeploy, that I
needed the params to be in the state the validate task would leave
them in.  This is a public test helper that sets up the params and
also sets up associated ivars to use in tests.  The validate
support file here has been updated to use this.  This allows other
libs to get the same validate test support.

@jcredding ready for review.
