### PR TITLE
add set Update task params test helper

### DIFF
--- a/lib/dk-abdeploy/test_helpers.rb
+++ b/lib/dk-abdeploy/test_helpers.rb
@@ -37,7 +37,8 @@ module Dk::ABDeploy
           Dk::ABDeploy::RELEASE_B_DIR_NAME
         )
 
-        @params = {
+        @params ||= {}
+        @params.merge!({
           Dk::ABDeploy::ROOT_PARAM_NAME          => @dk_abdeploy_root,
           Dk::ABDeploy::REPO_PARAM_NAME          => @dk_abdeploy_repo,
           Dk::ABDeploy::SHARED_DIR_PARAM_NAME    => @dk_abdeploy_shared,
@@ -45,7 +46,18 @@ module Dk::ABDeploy
           Dk::ABDeploy::RELEASES_DIR_PARAM_NAME  => @dk_abdeploy_releases,
           Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME => @dk_abdeploy_release_a,
           Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME => @dk_abdeploy_release_b
-        }
+        })
+      end
+
+      def set_dk_abdeploy_update_params
+        release_dirs = [
+          @params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME],
+          @params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+        ]
+
+        @params[Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME] = release_dirs.sample
+        release_dirs.delete(@params[Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME])
+        @params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME] = release_dirs.first
       end
 
     end

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -50,6 +50,24 @@ module Dk::ABDeploy::TestHelpers
       assert_equal exp, subject.params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
     end
 
+    should "setup the params the update task does" do
+      subject.set_dk_abdeploy_validate_params
+      subject.set_dk_abdeploy_update_params
+
+      exp_release_dirs = [
+        subject.params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME],
+        subject.params[Dk::ABDeploy::RELEASE_B_DIR_PARAM_NAME]
+      ]
+
+      exp_release_dirs.delete(
+        subject.params[Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME]
+      )
+      assert_equal 1, exp_release_dirs.size
+
+      exp = exp_release_dirs.first
+      assert_equal exp, subject.params[Dk::ABDeploy::DEPLOY_RELEASE_DIR_PARAM_NAME]
+    end
+
   end
 
 end


### PR DESCRIPTION
This is so 3rd-party tools can test as if the Update task had run
and set its params.

Note: this also cleans up the Validate params test helper to not
stomp any other params that may already exist.  This is to just
be friendly and not surprise the user.

@jcredding ready for review.
