### PR TITLE
tweak the BundlerCmdStr util based on test usage

### DIFF
--- a/lib/dk-abdeploy/utils/bundler_cmd_str.rb
+++ b/lib/dk-abdeploy/utils/bundler_cmd_str.rb
@@ -6,15 +6,13 @@ module Dk::ABDeploy::Utils
 
   module BundlerCmdStr
 
-    def self.new(params, cmd_str, opts = nil)
+    def self.new(cmd_str, params, opts = nil)
       opts ||= {}
 
-      opts[:root] ||= Dk::ABDeploy::CURRENT_DIR_PARAM_NAME
-      opts[:env]  ||= ""
+      opts[:root_param] ||= Dk::ABDeploy::CURRENT_DIR_PARAM_NAME
+      opts[:env]        ||= ""
 
-      cmd_root = params.key?(opts[:root]) ? params[opts[:root]] : opts[:root]
-
-      "cd #{cmd_root} && #{opts[:env]} bundle exec #{cmd_str}"
+      "cd #{params[opts[:root_param]]} && #{opts[:env]} bundle #{cmd_str}"
     end
 
     module TestHelpers

--- a/test/unit/utils/bundler_cmd_str_tests.rb
+++ b/test/unit/utils/bundler_cmd_str_tests.rb
@@ -12,30 +12,22 @@ module Dk::ABDeploy::Utils::BundlerCmdStr
       }
       @cmd_str = Factory.string
 
-      @bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@params, @cmd_str)
+      @bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@cmd_str, @params)
     end
     subject{ @bundler_cmd_str }
 
     should "build a bundler cmd str to run" do
-      assert_includes "&&  bundle exec #{@cmd_str}", subject
+      assert_includes "&&  bundle #{@cmd_str}", subject
     end
 
-    should "use dk-abdeploy's current dir param as the root path by default" do
+    should "use dk-abdeploy's current dir param as the root param by default" do
       exp = "cd #{@params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]} &&"
       assert_includes exp, subject
     end
 
-    should "use a custom root path if given" do
-      path = Factory.path
-      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@params, @cmd_str, {
-        :root => path
-      })
-      assert_includes "cd #{path} &&", bundler_cmd_str
-    end
-
-    should "use a custom param as the root path if given" do
-      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@params, @cmd_str, {
-        :root => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME
+    should "use a custom root param if given" do
+      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@cmd_str, @params, {
+        :root_param => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME
       })
 
       exp = "cd #{@params[Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME]} &&"
@@ -44,11 +36,11 @@ module Dk::ABDeploy::Utils::BundlerCmdStr
 
     should "use a custom env var string if given" do
       env = "#{Factory.string.upcase}=#{Factory.string}"
-      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@params, @cmd_str, {
+      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@cmd_str, @params, {
         :env => env
       })
 
-      assert_includes "&& #{env} bundle exec #{@cmd_str}", bundler_cmd_str
+      assert_includes "&& #{env} bundle #{@cmd_str}", bundler_cmd_str
     end
 
   end
@@ -65,23 +57,20 @@ module Dk::ABDeploy::Utils::BundlerCmdStr
     should have_imeths :assert_bundler_cmd_str
 
     should "prove a util is a bundler cmd that was built correctly" do
-      assert_bundler_cmd_str(@bundler_cmd_str, @params, @cmd_str)
-      assert_bundler_cmd_str(@bundler_cmd_str, @params, @cmd_str, {
-        :root => Dk::ABDeploy::CURRENT_DIR_PARAM_NAME
+      assert_bundler_cmd_str(@bundler_cmd_str, @cmd_str, @params)
+      assert_bundler_cmd_str(@bundler_cmd_str, @cmd_str, @params, {
+        :root_param => Dk::ABDeploy::CURRENT_DIR_PARAM_NAME
       })
-      assert_bundler_cmd_str(@bundler_cmd_str, @params, @cmd_str, {
-        :root => @params[Dk::ABDeploy::CURRENT_DIR_PARAM_NAME]
-      })
-      assert_bundler_cmd_str(@bundler_cmd_str, @params, @cmd_str, :env => '')
+      assert_bundler_cmd_str(@bundler_cmd_str, @cmd_str, @params, :env => '')
 
       env = "#{Factory.string.upcase}=#{Factory.string}"
-      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@params, @cmd_str, {
-        :root => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME,
-        :env  => env
+      bundler_cmd_str = Dk::ABDeploy::Utils::BundlerCmdStr.new(@cmd_str, @params, {
+        :root_param => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME,
+        :env        => env
       })
-      assert_bundler_cmd_str(bundler_cmd_str, @params, @cmd_str, {
-        :root => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME,
-        :env  => env
+      assert_bundler_cmd_str(bundler_cmd_str, @cmd_str, @params, {
+        :root_param => Dk::ABDeploy::RELEASE_A_DIR_PARAM_NAME,
+        :env        => env
       })
     end
 


### PR DESCRIPTION
So I was using this (and testing this) in a 3rd-party internal gem
and found a few things about the API confusing.  This attempts to
improve the api a bit:
- I chose to change the args order and pass the cmd str _then_ the
  params.  This just felt more natural - the first arg should
  be the cmd str itself b/c it is the most important precedent
  thing in play.
- I renamed the `:root` opt to `:root_param`.  This is more
  intention revealing.  This is now expected to _always_ be a
  param name and _never_ be an actual path.  This seemed
  reasonable since we require passing in the params to get the
  default root path anyway.
- I chose to remove 'exec' from the boilerplate cmd str.  This not
  only makes it more flexible, but better matches its name in that
  this is a _Bundler_ cmd str, not a "bundle exec" cmd str.

@jcredding ready for review - you cool with this?
