### PR TITLE
add a Cleanup task to reset the non-deploy release dir post-Update

### DIFF
--- a/lib/dk-abdeploy/cleanup.rb
+++ b/lib/dk-abdeploy/cleanup.rb
@@ -1,0 +1,40 @@
+require 'much-plugin'
+require 'dk/task'
+require "dk-abdeploy/constants"
+require "dk-abdeploy/update"
+require 'dk-abdeploy/validate'
+
+module Dk::ABDeploy
+
+  class Cleanup
+    include Dk::Task
+
+    desc "(dk-abdeploy) update the non-deploy release's source post-update"
+
+    before Validate
+
+    ssh_hosts SSH_HOSTS_GROUP_NAME
+
+    def run!
+      # current release dir is the one that was current pre-update - the
+      # non-deploy release dir
+      if params[CURRENT_RELEASE_DIR_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{CURRENT_RELEASE_DIR_PARAM_NAME.inspect} param set"
+      end
+      if params[REF_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{REF_PARAM_NAME.inspect} param set"
+      end
+
+      # reset the non-deploy release git repo
+      ssh! git_reset_cmd_str(params[CURRENT_RELEASE_DIR_PARAM_NAME], params[REF_PARAM_NAME])
+    end
+
+    private
+
+    def git_reset_cmd_str(repo_dir, ref)
+      Update.git_reset_cmd_str(repo_dir, ref)
+    end
+
+  end
+
+end

--- a/lib/dk-abdeploy/update.rb
+++ b/lib/dk-abdeploy/update.rb
@@ -14,6 +14,13 @@ module Dk::ABDeploy
 
     ssh_hosts SSH_HOSTS_GROUP_NAME
 
+    def self.git_reset_cmd_str(repo_dir, ref)
+      "cd #{repo_dir} && " \
+      "git fetch -q origin && " \
+      "git reset -q --hard #{ref} && " \
+      "git clean -q -d -x -f"
+    end
+
     def run!
       # validate required params are set
       if params[REF_PARAM_NAME].to_s.empty?
@@ -47,10 +54,7 @@ module Dk::ABDeploy
     end
 
     def git_reset_cmd_str(repo_dir, ref)
-      "cd #{repo_dir} && " \
-      "git fetch -q origin && " \
-      "git reset -q --hard #{ref} && " \
-      "git clean -q -d -x -f"
+      self.class.git_reset_cmd_str(repo_dir, ref)
     end
 
     module TestHelpers

--- a/test/unit/cleanup_tests.rb
+++ b/test/unit/cleanup_tests.rb
@@ -1,0 +1,97 @@
+require 'assert'
+require 'dk-abdeploy/cleanup'
+
+require 'dk/task'
+require 'dk/task_run'
+require 'dk-abdeploy'
+require 'dk-abdeploy/update'
+require 'test/support/validate'
+
+class Dk::ABDeploy::Cleanup
+
+  class UnitTests < Assert::Context
+    desc "Dk::ABDeploy::Cleanup"
+    setup do
+      @task_class = Dk::ABDeploy::Cleanup
+    end
+    subject{ @task_class }
+
+    should "be a Dk task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-abdeploy) update the non-deploy release's source post-update"
+      assert_equal exp, subject.description
+    end
+
+    should "run the Validate task as a before callback" do
+      assert_equal [Dk::ABDeploy::Validate], subject.before_callback_task_classes
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::ABDeploy::Update::TestHelpers
+
+    desc "when init"
+    setup do
+      @params.merge!({
+        Dk::ABDeploy::REF_PARAM_NAME => Factory.hex,
+      })
+      @runner = test_runner(@task_class, :params => @params)
+      @task = @runner.task
+    end
+    subject{ @task }
+
+    should "know its ssh hosts" do
+      assert_equal Dk::ABDeploy::SSH_HOSTS_GROUP_NAME, subject.dk_dsl_ssh_hosts
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+    subject{ @runner }
+
+    should "run the Validate callback and 1 ssh cmd" do
+      assert_equal 2, subject.runs.size
+    end
+
+    should "run an ssh cmd to reset the current release git repo" do
+      _, git_reset_ssh = subject.runs
+
+      repo_dir = @params[Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME]
+      ref      = @params[Dk::ABDeploy::REF_PARAM_NAME]
+      exp      = Dk::ABDeploy::Update.git_reset_cmd_str(repo_dir, ref)
+      assert_equal exp, git_reset_ssh.cmd_str
+    end
+
+    should "complain if the current release dir or ref params aren't set" do
+      value = [nil, ''].sample
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME                 => value,
+        Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME                 => Factory.string,
+        Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME => value
+      })
+      assert_raises(ArgumentError){ runner.run }
+
+      runner = test_runner(@task_class, :params => {
+        Dk::ABDeploy::REF_PARAM_NAME                 => value,
+        Dk::ABDeploy::CURRENT_RELEASE_DIR_PARAM_NAME => Factory.string
+      })
+      assert_raises(ArgumentError){ runner.run }
+    end
+
+  end
+
+end


### PR DESCRIPTION
This keeps the non-deploy release dir (which will be the deploy
release dir on the next Update) from getting too far behind the
ref.  This doesn't really matter if each deploy has just 1 new
commit.  However, if the deploys pile up many commits each, the
reset may end up taking a long time.  This also ensures that both
release dirs will be at the same commit after cleanup.

This task should be run at the end of deploys, once all systems
and runtimes are referencing and usings the original deploy
release dir.

@jcredding ready for review.
